### PR TITLE
Use geckodriver instead of Selenium standalone server hub

### DIFF
--- a/README
+++ b/README
@@ -5,12 +5,12 @@ Usage:
 
   $ docker run --net=host -t quay.io/wakaba/firefoxdriver:stable /fx
 
-... then access <http://localhost:9516/wd/hub/{path}>.
+... then access <http://localhost:9516/{path}>.
 
 Docker Hub: <https://registry.hub.docker.com/u/wakaba/docker-firefoxdriver/>
 
 
-Firefox Driver <https://code.google.com/p/selenium/wiki/FirefoxDriver>
+geckodriver <https://github.com/mozilla/geckodriver>
 The WebDriver Wire Protocol
 <https://code.google.com/p/selenium/wiki/JsonWireProtocol>
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
 test:
   override:
     - docker run --name server -d -p 5511:9516 quay.io/wakaba/firefoxdriver:stable /fx; sleep 10
-    - curl -f http://localhost:5511/wd/hub/status
+    - curl -f http://localhost:5511/status
     - docker logs server
 
 deployment:

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -12,24 +12,22 @@ RUN wget https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted
     fc-cache && \
     rm NotoSansCJKjp-hinted.zip
 
-## <http://www.seleniumhq.org/download/>
-## <http://selenium-release.storage.googleapis.com/index.html>
-RUN wget `wget -O - https://raw.githubusercontent.com/wakaba/docker-firefoxdriver/master/stable/selenium-url`
+# geckodriver <https://github.com/mozilla/geckodriver>
+RUN wget -np https://github.com/mozilla/geckodriver/releases/download/v0.14.0/geckodriver-v0.14.0-linux64.tar.gz && \
+    tar xvf geckodriver-*-linux64.tar.gz && \
+    rm geckodriver-*-linux64.tar.gz && \
+    chmod u+x /geckodriver
 
 RUN wget -m -np https://ftp.mozilla.org/pub/firefox/releases/`wget -O - https://raw.githubusercontent.com/manakai/data-web-impls/master/data/firefox-latest.txt`/linux-x86_64/en-US/ && \
     tar jvxf /ftp.mozilla.org/pub/firefox/releases/*/linux-x86_64/en-US/firefox-*.tar.bz2 && \
     rm -fr /ftp.mozilla.org
 
-RUN echo "#!/bin/bash" > /runfx && \
-    echo 'DISPLAY=:0 /firefox/firefox "$*"' >> /runfx && \
-    chmod u+x /runfx
-
 RUN echo "#!/bin/bash" > /fx && \
     echo 'Xvfb :0 -screen 0 1024x768x24 &' >> /fx && \
-    echo 'java -jar selenium-server-standalone-*.jar -port 9516 -Dwebdriver.firefox.bin=/runfx' >> /fx && \
+    echo 'DISPLAY=:0 /geckodriver --host 0.0.0.0 --port 9516 --binary /firefox/firefox' >> /fx && \
     chmod u+x /fx
 
 RUN echo "#!/bin/bash" > /fx-port && \
     echo 'Xvfb :0 -screen 0 1024x768x24 &' >> /fx-port && \
-    echo 'java -jar selenium-server-standalone-*.jar -port $1 -Dwebdriver.firefox.bin=/runfx' >> /fx-port && \
+    echo 'DISPLAY=:0 /geckodriver --host 0.0.0.0 --port $1 --binary /firefox/firefox' >> /fx-port && \
     chmod u+x /fx-port

--- a/stable/geckodriver-url
+++ b/stable/geckodriver-url
@@ -1,0 +1,1 @@
+https://github.com/mozilla/geckodriver/releases/download/v0.14.0/geckodriver-v0.14.0-linux64.tar.gz

--- a/stable/selenium-url
+++ b/stable/selenium-url
@@ -1,1 +1,0 @@
-https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar


### PR DESCRIPTION
As Mozilla's [geckodriver](https://github.com/mozilla/geckodriver) is required for Firefox 47+, I changed to use geckodriver instead of Selenium standalone server hub. (Issue #1)

This pull request makes endpoint change from http://localhost:9516/wd/hub/{path} to http://localhost:9516/{path}. Is it OK?

## Alternative way

There is alternative way : introducing geckodriver and updating Selenium standalone server hub to version 3.1.