### PR TITLE
Add package for `fc-cache` and packages for dependencies of Firefox

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:sid
 
 RUN (apt-get update || apt-get update) && \
-    (apt-get install -y wget bzip2 unzip xvfb default-jre fonts-noto || \
-     apt-get install -y wget bzip2 unzip xvfb default-jre fonts-noto) && \
+    (apt-get install -y wget bzip2 unzip xvfb fontconfig fonts-noto || \
+     apt-get install -y wget bzip2 unzip xvfb fontconfig fonts-noto) && \
     rm -rf /var/lib/apt/lists/*
 
 RUN wget https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip && \
@@ -18,7 +18,14 @@ RUN wget -np https://github.com/mozilla/geckodriver/releases/download/v0.14.0/ge
     rm geckodriver-*-linux64.tar.gz && \
     chmod u+x /geckodriver
 
-RUN wget -m -np https://ftp.mozilla.org/pub/firefox/releases/`wget -O - https://raw.githubusercontent.com/manakai/data-web-impls/master/data/firefox-latest.txt`/linux-x86_64/en-US/ && \
+# Firefox
+# To install dependencies of Firefox, firefox package is installed and then be purged.
+RUN (apt-get update || apt-get update) && \
+    (apt-get -y --no-install-recommends install firefox dbus || \
+     apt-get -y --no-install-recommends install firefox dbus) && \
+    apt-get -y purge firefox && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget -m -nv -np https://ftp.mozilla.org/pub/firefox/releases/`wget -O - https://raw.githubusercontent.com/manakai/data-web-impls/master/data/firefox-latest.txt`/linux-x86_64/en-US/ && \
     tar jvxf /ftp.mozilla.org/pub/firefox/releases/*/linux-x86_64/en-US/firefox-*.tar.bz2 && \
     rm -fr /ftp.mozilla.org
 


### PR DESCRIPTION
## Problem

Docker image needs more Firefox dependencies.

When I executed `docker run -it --rm -t quay.io/wakaba/firefoxdriver:stable /firefox/firefox -v`, following error occurred.

```
XPCOMGlueLoad error for file /firefox/libxul.so:
libdbus-glib-1.so.2: cannot open shared object file: No such file or directory
Couldn't load XPCOM.
```

## What this pull request do

* Remove `default-jre` package because it's already unnecessary (It was used by Selenium.)
* Add `fontconfig` package for `fc-cache` command
* Add packages for dependencies of Firefox
    * To install dependencies of Firefox, firefox package is installed and then be purged
    * `dbus` package is also required because the message “D-Bus library appears to be incorrectly set up” is shown if it's not installed
        * See : http://qiita.com/nobuoka/items/96b7cdd733cf5be044ae (Japanese)
