### PR TITLE
Specify `TEST_SERVER_HOSTNAME` on running tests of perl-web-driver-client

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,11 +9,12 @@ dependencies:
     - docker build -t quay.io/wakaba/firefoxdriver:stable stable
     - git clone https://github.com/manakai/perl-web-driver-client
     - cd perl-web-driver-client && make test-deps
+    - ip route | awk '/docker0/ { print $NF }' > docker0-ip.txt; cat docker0-ip.txt
 test:
   override:
-    - docker run --name server -d -p 5511:9516 quay.io/wakaba/firefoxdriver:stable /fx; sleep 10
+    - docker run --name server -d -p 5511:9516 --add-host=dockerhost:`cat docker0-ip.txt` quay.io/wakaba/firefoxdriver:stable /fx && sleep 10
     - curl -f http://localhost:5511/status
-    - cd perl-web-driver-client && TEST_WD_URL=http://localhost:5511 WEBUA_DEBUG=2 make test
+    - cd perl-web-driver-client && TEST_WD_URL=http://localhost:5511 WEBUA_DEBUG=2 TEST_SERVER_LISTEN_HOST=0.0.0.0 TEST_SERVER_HOSTNAME=dockerhost make test
     - docker logs server
 
 deployment:


### PR DESCRIPTION
Current tests of perl-web-driver-client requires being able to access to test server from Docker container.

This change is equivalent to [the change applied to docker-chromedriver](https://github.com/wakaba/docker-chromedriver/commit/ae01f4a19b82a43bc49ac613121122d9189af13d).

# This change fixes some of problems

This change cannot fix all of problems of current build, but fixes some of them.

## Before

https://circleci.com/gh/wakaba/docker-firefoxdriver/773

```
Test Summary Report
-------------------
t/basic.t             (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
  Parse errors: Bad plan.  You planned 2 tests but ran 1.
t/session-element.t   (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
  Parse errors: Bad plan.  You planned 6 tests but ran 1.
t/session-http.t      (Wstat: 256 Tests: 4 Failed: 1)
  Failed test:  3
  Non-zero exit status: 1
t/session-navigate.t  (Wstat: 512 Tests: 7 Failed: 2)
  Failed tests:  4, 7
  Non-zero exit status: 2
  Parse errors: Bad plan.  You planned 26 tests but ran 7.
t/session-screenshot.t (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
  Parse errors: Bad plan.  You planned 2 tests but ran 1.
t/session-script.t    (Wstat: 768 Tests: 12 Failed: 3)
  Failed tests:  5, 8, 12
  Non-zero exit status: 3
  Parse errors: Bad plan.  You planned 20 tests but ran 12.
Files=6, Tests=26, 74 wallclock secs ( 0.12 usr  0.05 sys +  3.27 cusr  0.46 csys =  3.90 CPU)
Result: FAIL
```

## After

https://circleci.com/gh/nobuoka/docker-firefoxdriver/15

```
Test Summary Report
-------------------
t/basic.t             (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
t/session-http.t      (Wstat: 256 Tests: 4 Failed: 1)
  Failed test:  3
  Non-zero exit status: 1
Files=6, Tests=60, 110 wallclock secs ( 0.19 usr  0.09 sys +  4.37 cusr  0.46 csys =  5.11 CPU)
Result: FAIL
```